### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ jobs:
             vsix_type = "insiders"
           else:
             vsix_type = "release"
-          print(f"::set-output name=vsix_name::ms-python-{vsix_type}.vsix")
-          print(f"::set-output name=vsix_artifact_name::ms-python-{vsix_type}-vsix")
+          print(f"vsix_name=ms-python-{vsix_type}.vsix >> $GITHUB_OUTPUT")
+          print(f"vsix_artifact_name=ms-python-{vsix_type}-vsix >> $GITHUB_OUTPUT")
 
   build-vsix:
     name: Create VSIX

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ jobs:
             vsix_type = "insiders"
           else:
             vsix_type = "release"
-          print(f"vsix_name=ms-python-{vsix_type}.vsix >> $GITHUB_OUTPUT")
-          print(f"vsix_artifact_name=ms-python-{vsix_type}-vsix >> $GITHUB_OUTPUT")
+          print(f"vsix_name=ms-python-{vsix_type}.vsix >> "$GITHUB_OUTPUT"")
+          print(f"vsix_artifact_name=ms-python-{vsix_type}-vsix >> "$GITHUB_OUTPUT"")
 
   build-vsix:
     name: Create VSIX


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


